### PR TITLE
Support secret parameter

### DIFF
--- a/lib/fluent/plugin/in_mysql_query.rb
+++ b/lib/fluent/plugin/in_mysql_query.rb
@@ -10,7 +10,7 @@ module Fluent
     config_param :host, :string, :default => 'localhost'
     config_param :port, :integer, :default => 3306
     config_param :username, :string, :default => 'root'
-    config_param :password, :string, :default => nil
+    config_param :password, :string, :default => nil, :secret => true
     config_param :database, :string, :default => nil
     config_param :encoding, :string, :default => 'utf8'
     config_param :interval, :time, :default => '1m'


### PR DESCRIPTION
Fluentd v0.12 supports secret parameters feature.
This feature works as below:

```log
  <source>
    type mysql_query
    host localhost
    port 3306
    username nagios
    password xxxxxx
    interval 30s
    tag input.mysql
    query SHOW VARIABLES LIKE 'Thread_%'
    record_hostname yes
    nest_result yes
    nest_key data
    row_count yes
    row_count_key row_count
  </source>
  <match input.mysql>
    type stdout
  </match>
```

If you use older version of Fluentd, `:secret => true` in config_param will be simply ignored.