### PR TITLE
If the hostname variable is not present, return an empty string

### DIFF
--- a/lib/fluent/plugin/in_mysql_query.rb
+++ b/lib/fluent/plugin/in_mysql_query.rb
@@ -94,6 +94,8 @@ module Fluent
       query("SHOW VARIABLES LIKE 'hostname'").each do |row|
         return row.fetch('Value')
       end
+      # hostname variable is not present
+      return ''
     end
 
     def get_exec_result


### PR DESCRIPTION
This is necessary to use the `mysql_query` Fluentd plugin on the MySQL-like [ProxySQL](https://github.com/sysown/proxysql/) Admin database, which does not have a `hostname` variable.